### PR TITLE
fix: access-works link was missing closing anchor part

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
                 <li><a href="https://www.americanprogress.org/article/covid-19-likely-resulted-in-1-2-million-more-disabled-people-by-the-end-of-2021-workplaces-and-policy-will-need-to-adapt/">COVID-19 Likely Resulted in 1.2 Million More Disabled People by the End of 2021—Workplaces and Policy Will Need to Adapt</a></li>
                 <li><a href="https://feather.ca/shift-left/">The ongoing evolution of 'Shift left'</a></li>
                 <li><a href="https://makeitfable.com/">Fable Tech Labs</a></li>
-                <li><a href="https://access-works.com/">Access Works</li>
+                <li><a href="https://access-works.com/">Access Works</a></li>
                 <li><a href="https://www.interaction-design.org/literature/topics/affordances">Affordances in Interaction Design</a></li>
                 <li><a href="https://source.opennews.org/articles/motion-sick/">Your Interactive Makes Me Sick</a></li>
                 <li><a href="https://web.dev/prefers-reduced-motion/">prefers-reduced-motion: Sometimes less movement is more</a></li>


### PR DESCRIPTION
While running a validation on the page, I found out that 1 item link was missing a closing anchor tag